### PR TITLE
Submission List で現在のページを視覚的にわかりやすくしたい

### DIFF
--- a/main.go
+++ b/main.go
@@ -247,6 +247,7 @@ func submitList(ctx *gin.Context) {
 		"Problem":     submitFilter.Problem,
 		"Status":      submitFilter.Status,
 		"Pages":       pages,
+    "Page":        submitFilter.Page,
 		"Order":       submitFilter.Order,
 		"FilterUser":  submitFilter.User,
 		"LangMap":     langMap,

--- a/main.go
+++ b/main.go
@@ -247,7 +247,7 @@ func submitList(ctx *gin.Context) {
 		"Problem":     submitFilter.Problem,
 		"Status":      submitFilter.Status,
 		"Pages":       pages,
-    "Page":        submitFilter.Page,
+		"Page":        submitFilter.Page,
 		"Order":       submitFilter.Order,
 		"FilterUser":  submitFilter.User,
 		"LangMap":     langMap,

--- a/templates/submitlist.html
+++ b/templates/submitlist.html
@@ -54,7 +54,13 @@
             <ul class="uk-pagination uk-flex-center">
                 {{range $p := .Pages}}
                     <li>
-                        <a href="?page={{$p}}{{if $.Problem}}&amp;problem={{$.Problem}}{{end}}{{if $.FilterUser}}&amp;user={{$.FilterUser}}{{end}}{{if $.Status}}&amp;status={{$.Status}}{{end}}{{if $.Order}}&amp;order={{$.Order}}{{end}}">{{$p}}</a>
+                        <a href="?page={{$p}}{{if $.Problem}}&amp;problem={{$.Problem}}{{end}}{{if $.FilterUser}}&amp;user={{$.FilterUser}}{{end}}{{if $.Status}}&amp;status={{$.Status}}{{end}}{{if $.Order}}&amp;order={{$.Order}}{{end}}">
+                            {{if eq $p $.Page}}
+                                <span class="uk-badge">{{$p}}</span>
+                            {{else}}
+                                {{$p}}
+                            {{end}}
+                        </a>
                     </li>
                 {{end}}
             </ul>


### PR DESCRIPTION
#49 

## 概要
見た目に関わる PR なので，少しでも問題があれば却下してください．
既存のコードを参考にし，コードを少し追加しました．
現在のページに応じて，[UIkit の Badge](https://getuikit.com/docs/badge) をあてました．

## キャプチャ
### before
<img width="1255" alt="スクリーンショット 2020-07-17 1 13 46" src="https://user-images.githubusercontent.com/47474057/87697275-dc35f180-c7cc-11ea-8887-fcfa19eda675.png">

### after
<img width="1255" alt="スクリーンショット 2020-07-17 1 13 55" src="https://user-images.githubusercontent.com/47474057/87697287-e0620f00-c7cc-11ea-9561-f90e0af5920d.png">

## やったこと
- `main.go` の `htmlWithUser` に，現在のページを表す `Page` を追加した
- `templates/submitlist.html` で，`Page` に応じて UIkit の Badge をあてるようにした
- `go fmt` でコードのフォーマットを行なった