### PR TITLE
replace "Mib" with "MiB"

### DIFF
--- a/src/components/SubmissionTable.tsx
+++ b/src/components/SubmissionTable.tsx
@@ -97,7 +97,7 @@ const SubmissionTable: React.FC<InnerProps> = props => {
               <TableCell>{Math.round(row.getTime() * 1000)} ms</TableCell>
               <TableCell>
                 {row.getMemory() === -1 ? -1 : row.getMemory() / 1024 / 1024}{" "}
-                Mib
+                MiB
               </TableCell>
             </TableRow>
           ))}

--- a/src/pages/SubmissionInfo.tsx
+++ b/src/pages/SubmissionInfo.tsx
@@ -151,7 +151,7 @@ const SubmissionInfo: React.FC<Props> = props => {
                             {row.getMemory() === -1
                               ? -1
                               : row.getMemory() / 1024 / 1024}{" "}
-                            Mib
+                            MiB
                           </TableCell>
                         </TableRow>
                       ))}


### PR DESCRIPTION
For units of information, "b" is usually used for "bit" and "B" is for "byte". So "MiB" is correct for "Mebibyte".

typo を見つけたので直しておきます。