### PR TITLE
Store selectedIdx in location.state

### DIFF
--- a/src/pages/Problems.tsx
+++ b/src/pages/Problems.tsx
@@ -38,7 +38,7 @@ const ProblemsTabs: React.FC<{
   useEffect(() => {
     const state = location.state as ProblemsTabState;
     if (state?.selectedIdx !== selectedIdx) {
-      navigate(".", { state: { selectedIdx } });
+      navigate(".", { state: { selectedIdx }, replace: true });
     }
   }, [selectedIdx]);
   useEffect(() => {

--- a/src/pages/Problems.tsx
+++ b/src/pages/Problems.tsx
@@ -3,7 +3,7 @@ import CircularProgress from "@mui/material/CircularProgress";
 import Typography from "@mui/material/Typography";
 import Alert from "@mui/material/Alert";
 import Link from "@mui/material/Link";
-import React, { useContext, useState } from "react";
+import React, { useContext, useEffect, useState } from "react";
 import {
   useProblemCategories,
   useProblemList,
@@ -17,13 +17,36 @@ import {
   categoriseProblems,
 } from "../utils/ProblemCategorizer";
 import { Tab, Tabs } from "@mui/material";
+import { useLocation, useNavigate } from "react-router-dom";
+
+type ProblemsTabState = {
+  selectedIdx?: number;
+} | null;
 
 const ProblemsTabs: React.FC<{
   categories: CategorisedProblems;
   solvedStatus: { [problem: string]: "latest_ac" | "ac" };
 }> = (props) => {
   const { categories, solvedStatus } = props;
-  const [selectedIdx, setSelectedIdx] = useState(0);
+  const navigate = useNavigate();
+  const location = useLocation();
+  const [selectedIdx, setSelectedIdx] = useState(() => {
+    const state = location.state as ProblemsTabState;
+    return state?.selectedIdx ?? 0;
+  });
+
+  useEffect(() => {
+    const state = location.state as ProblemsTabState;
+    if (state?.selectedIdx !== selectedIdx) {
+      navigate(".", { state: { selectedIdx } });
+    }
+  }, [selectedIdx]);
+  useEffect(() => {
+    const state = location.state as ProblemsTabState;
+    if (state?.selectedIdx) {
+      setSelectedIdx(state.selectedIdx);
+    }
+  }, [location.state]);
 
   const categoriesTab = (
     <Box sx={{ borderBottom: 1, borderColor: "divider" }}>


### PR DESCRIPTION
## 概要
- 問題一覧ページでselectedIdxが変更されたとき,　location.stateに新しいselectedIdxをpushするようにしたい。（Tabでの絞り込みを変更するたびにHistoryが積まれていきます)
- selectedIdxを初期化するときにlocation.stateの中身があったらそれを使うようにした。

## 要議論
現在はタブの絞り込みを更新したときにHistoryに新しいstateをpushしているが、replaceの方が良いかも？

Tabを色々クリックしたあと、ブラウザバックしたとき
- 一つ前にクリックしていたTab
- 一つ前のページ
のどちらに飛ぶ方が良いかによる。前者ならpush、 後者ならrpelace.

## 様子
![history state](https://user-images.githubusercontent.com/544494/181277589-347caac4-753f-489d-b49b-df6c593f9654.gif)


## 関連Issue
https://github.com/yosupo06/library-checker-frontend/issues/123