### PR TITLE
submit連打による多重提出の防止

### DIFF
--- a/src/pages/ProblemInfo.tsx
+++ b/src/pages/ProblemInfo.tsx
@@ -6,7 +6,7 @@ import Divider from "@mui/material/Divider";
 import FormControl from "@mui/material/FormControl";
 import MenuItem from "@mui/material/MenuItem";
 import Select from "@mui/material/Select";
-import React, { useContext, useState } from "react";
+import React, { useContext, useRef, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { useLocalStorage } from "react-use";
 import library_checker_client, {
@@ -82,6 +82,7 @@ const ProblemInfo: React.FC = () => {
   const langListQuery = useLangList();
 
   const version = problemInfoQuery.data?.publicFilesHash ?? "";
+  const submitProcessing = useRef(false);
 
   const solveHppQuery = useQuery(
     ["header", problemId],
@@ -120,9 +121,11 @@ const ProblemInfo: React.FC = () => {
       </Box>
     );
   }
-
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
+    if (submitProcessing.current) return;
+    submitProcessing.current = true;
+
     if (!lang) {
       console.log("Please select lang");
       return;
@@ -133,6 +136,7 @@ const ProblemInfo: React.FC = () => {
         (auth && authMetadata(auth.state)) ?? undefined
       )
       .then((resp) => {
+        submitProcessing.current = false;
         navigate(`/submission/${resp.response.id}`);
       });
   };

--- a/src/pages/ProblemInfo.tsx
+++ b/src/pages/ProblemInfo.tsx
@@ -121,6 +121,7 @@ const ProblemInfo: React.FC = () => {
       </Box>
     );
   }
+
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     if (submitProcessing.current) return;


### PR DESCRIPTION
#128 
submit 連打による多重提出の防止です。
login処理、profileの更新処理、登録処理にも似たようなコードがありましたが、とりあえず直していません（直すのは必要であればすぐに可能です）
https://github.com/yosupo06/library-checker-frontend/blob/39781c272be176d27d17695a39d8dec1789dc5e4/src/pages/Login.tsx#L20
https://github.com/yosupo06/library-checker-frontend/blob/39781c272be176d27d17695a39d8dec1789dc5e4/src/pages/Register.tsx#L22
https://github.com/yosupo06/library-checker-frontend/blob/39781c272be176d27d17695a39d8dec1789dc5e4/src/pages/Profile.tsx#L59