### PR TITLE
フォーカスするまでソースコードのリサイズがされないバグの修正

### DIFF
--- a/src/components/SourceEditor.tsx
+++ b/src/components/SourceEditor.tsx
@@ -1,6 +1,7 @@
 import "katex/dist/katex.min.css";
 import React, { useState } from "react";
 import Editor from "@monaco-editor/react";
+import { editor } from "monaco-editor";
 
 interface Props {
   value: string;
@@ -51,6 +52,12 @@ const SourceEditor: React.FC<Props> = (props) => {
 
   const mode = editorMode(language);
 
+  const updateHeight = (editor: editor.IStandaloneCodeEditor) => {
+    if (autoHeight) {
+      setEditorHeight(Math.max(minHeight, editor.getContentHeight()));
+    }
+  };
+
   return (
     <Editor
       value={value}
@@ -61,10 +68,9 @@ const SourceEditor: React.FC<Props> = (props) => {
       }}
       onMount={(editor) => {
         editor.onDidContentSizeChange(() => {
-          if (autoHeight) {
-            setEditorHeight(Math.max(minHeight, editor.getContentHeight()));
-          }
+          updateHeight(editor);
         });
+        updateHeight(editor);
       }}
       options={{
         readOnly: readOnly,


### PR DESCRIPTION
#160
再現性が低く検証が難しいのですが、自分の環境にてほぼ確実にこのバグが確認されていた提出
https://judge.yosupo.jp/submission/23714
においてこの変更を加えたことで再現しなくなったため修正できたと考えています。