### PR TITLE
163 support responsive design

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -28,6 +28,11 @@
   color: #61dafb;
 }
 
+.katex-display {
+  overflow-x: auto;
+  overflow-y: hidden;
+}
+
 @keyframes App-logo-spin {
   from {
     transform: rotate(0deg);

--- a/src/components/NavBar/index.tsx
+++ b/src/components/NavBar/index.tsx
@@ -5,6 +5,7 @@ import AppBar from "@mui/material/AppBar";
 import Toolbar from "@mui/material/Toolbar";
 import Menu from "@mui/material/Menu";
 import { GitHub } from "@mui/icons-material";
+import MenuIcon from "@mui/icons-material/Menu";
 import React, { useContext } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { AuthContext } from "../../contexts/AuthContext";
@@ -13,7 +14,7 @@ import flagJA from "./flag_ja.svg";
 import flagUS from "./flag_us.svg";
 import { styled } from "@mui/system";
 import { useUserInfo } from "../../api/client_wrapper";
-import { Box } from "@mui/material";
+import { Drawer, IconButton } from "@mui/material";
 
 const NavbarLink = styled(Link)({
   color: "inherit",
@@ -41,7 +42,7 @@ const LangSelect = () => {
       }
       sx={{
         ml: "auto",
-        mr: 0.2,
+        mr: { xs: "auto", sm: 0.2 },
       }}
     >
       <MenuItem value="en">
@@ -66,7 +67,7 @@ const ToolsMenu: React.FC = () => {
   };
 
   return (
-    <Box>
+    <>
       <NavbarButton color="inherit" onClick={handleClick}>
         Tools
       </NavbarButton>
@@ -87,7 +88,7 @@ const ToolsMenu: React.FC = () => {
           <NavbarLink to={`/tool/statementviewer`}>Statement Viewer</NavbarLink>
         </MenuItem>
       </Menu>
-    </Box>
+    </>
   );
 };
 
@@ -156,42 +157,88 @@ const NavBar: React.FC = () => {
   const isDeveloper =
     userInfoQuery.isSuccess && userInfoQuery.data.user?.isDeveloper;
   const userMenu = UserMenu();
+  const elements = (
+    <>
+      <Button color="inherit" href="/submissions">
+        Submissions
+      </Button>
+      <Button color="inherit" href="/ranking">
+        Ranking
+      </Button>
+      <Button color="inherit" href="/help">
+        Help
+      </Button>
+      {isDeveloper && <ToolsMenu />}
+      <LangSelect />
+      {userMenu}
+      <Button
+        color="inherit"
+        href="https://github.com/yosupo06/library-checker-problems"
+        target="_blank"
+        rel="noopener"
+      >
+        <GitHub />
+      </Button>
+    </>
+  );
+
+  const title = (
+    <>
+      <Button
+        color="inherit"
+        href="/"
+        sx={{
+          fontSize: "16px",
+          fontWeight: "bolder",
+        }}
+      >
+        Library Checker
+      </Button>
+    </>
+  );
+
+  const [open, setOpen] = React.useState(false);
+
+  const toggleDrawerOpen = () => {
+    setOpen(!open);
+  };
 
   return (
-    <AppBar position="static">
-      <Toolbar>
-        <Button
-          color="inherit"
-          href="/"
-          sx={{
-            fontSize: "16px",
-            fontWeight: "bolder",
-          }}
-        >
-          Library Checker
-        </Button>
-        <Button color="inherit" href="/submissions">
-          Submissions
-        </Button>
-        <Button color="inherit" href="/ranking">
-          Ranking
-        </Button>
-        <Button color="inherit" href="/help">
-          Help
-        </Button>
-        {isDeveloper && <ToolsMenu />}
-        <LangSelect />
-        {userMenu}
-        <Button
-          color="inherit"
-          href="https://github.com/yosupo06/library-checker-problems"
-          target="_blank"
-          rel="noopener"
-        >
-          <GitHub />
-        </Button>
-      </Toolbar>
-    </AppBar>
+    <>
+      <AppBar position="static">
+        <Toolbar sx={{ display: { xs: "none", sm: "flex" } }}>
+          {title}
+          {elements}
+        </Toolbar>
+
+        <Toolbar sx={{ display: { xs: "flex", sm: "none" } }}>
+          {title}
+          <IconButton
+            onClick={toggleDrawerOpen}
+            sx={{
+              ml: "auto",
+              mr: 0.2,
+            }}
+            color="inherit"
+          >
+            <MenuIcon />
+          </IconButton>
+        </Toolbar>
+      </AppBar>
+      <Drawer
+        sx={{
+          display: { xs: "flex", sm: "none" },
+        }}
+        PaperProps={{
+          sx: { width: "35%" },
+        }}
+        anchor="left"
+        open={open}
+        onClose={toggleDrawerOpen}
+      >
+        {elements}
+      </Drawer>
+    </>
   );
 };
 


### PR DESCRIPTION
close #163 
# 概要
library checker のレスポンシブ対応を行った

# 変更前
![Screenshot_2023-09-01-15-47-47-90_40deb401b9ffe8e1df2f1cc5ba480b12](https://github.com/yosupo06/library-checker-frontend/assets/10681598/dc630901-9424-4e3b-a54a-47b9cc394dd8) ![Screenshot_2023-09-01-15-48-12-78_40deb401b9ffe8e1df2f1cc5ba480b12](https://github.com/yosupo06/library-checker-frontend/assets/10681598/6a26cb7a-49b3-47ee-90e9-33cb378127d5) ![Screenshot_2023-09-01-15-48-25-98_40deb401b9ffe8e1df2f1cc5ba480b12](https://github.com/yosupo06/library-checker-frontend/assets/10681598/2df08341-1efc-41bc-9494-674e21057db5)

# 変更後
![Screenshot_2023-09-01-15-46-40-95_40deb401b9ffe8e1df2f1cc5ba480b12](https://github.com/yosupo06/library-checker-frontend/assets/10681598/6a951a16-8d86-4e44-9cb5-5822a9154ab5) ![Screenshot_2023-09-01-15-46-56-76_40deb401b9ffe8e1df2f1cc5ba480b12](https://github.com/yosupo06/library-checker-frontend/assets/10681598/115776fd-7233-4453-9287-551e37021fef) ![Screenshot_2023-09-01-15-47-08-79_40deb401b9ffe8e1df2f1cc5ba480b12](https://github.com/yosupo06/library-checker-frontend/assets/10681598/8a62f223-e7f5-4ecd-9187-144a0aa6f8f6)

# 変更点
以下の変更を加えた
- 横幅が 600px 未満の時ヘッダーをハンバーガーメニューに切り替える
- 数式のみの横スクロールを許可する
# 影響範囲
UI に大幅に変更を与えます
