### PR TITLE
Add pagination to ranking page

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "prettier": "prettier --write \"src/**/*.{ts,js,tsx,jsx}\"",
     "prettier:check": "prettier --check \"src/**/*.{ts,js,tsx,jsx}\"",
     "protoc": "protoc --ts_out src/proto --proto_path ${PROTO_PATH} ${PROTO_PATH}/library_checker.proto",
-    "test": "vitest",
+    "test": "vitest run",
     "coverage": "vitest run --coverage"
   },
   "browserslist": {

--- a/src/api/client_wrapper.ts
+++ b/src/api/client_wrapper.ts
@@ -83,10 +83,13 @@ export const useLangList = (): UseQueryResult<LangListResponse> =>
     queryFn: async () => await client.langList({}, {}).response,
   });
 
-export const useRanking = (): UseQueryResult<RankingResponse> =>
+export const useRanking = (
+  skip: number = 0,
+  limit: number = 100,
+): UseQueryResult<RankingResponse> =>
   useQuery({
-    queryKey: ["ranking"],
-    queryFn: async () => await client.ranking({}, {}).response,
+    queryKey: ["ranking", skip, limit],
+    queryFn: async () => await client.ranking({ skip, limit }, {}).response,
   });
 
 export const useProblemInfo = (

--- a/src/components/RankingList.tsx
+++ b/src/components/RankingList.tsx
@@ -1,6 +1,6 @@
 import Box from "@mui/material/Box";
 import Typography from "@mui/material/Typography";
-import React from "react";
+import React, { useState } from "react";
 import { useRanking } from "../api/client_wrapper";
 import Table from "@mui/material/Table";
 import TableBody from "@mui/material/TableBody";
@@ -8,9 +8,15 @@ import TableCell from "@mui/material/TableCell";
 import TableContainer from "@mui/material/TableContainer";
 import TableHead from "@mui/material/TableHead";
 import TableRow from "@mui/material/TableRow";
+import Pagination from "@mui/material/Pagination";
+import Stack from "@mui/material/Stack";
 
 const RankingList: React.FC = () => {
-  const rankingQuery = useRanking();
+  const [page, setPage] = useState(1);
+  const limit = 50; // Users per page
+  const skip = (page - 1) * limit;
+  
+  const rankingQuery = useRanking(skip, limit);
 
   if (rankingQuery.isPending) {
     return (
@@ -27,15 +33,28 @@ const RankingList: React.FC = () => {
     );
   }
 
+  const totalCount = rankingQuery.data.count;
+  const totalPages = Math.ceil(totalCount / limit);
+  
   const rows = rankingQuery.data.statistics.map((e, index) => {
     return {
       id: index,
       name: e.name,
       count: e.count,
+      ranking: skip + index + 1, // Calculate actual ranking position
     };
   });
+
+  const handlePageChange = (event: React.ChangeEvent<unknown>, value: number) => {
+    setPage(value);
+  };
+
   return (
-    <Box style={{ height: 2000 }}>
+    <Box>
+      <Typography variant="h6" gutterBottom>
+        Total Users: {totalCount}
+      </Typography>
+      
       <TableContainer>
         <Table>
           <TableHead>
@@ -48,7 +67,7 @@ const RankingList: React.FC = () => {
           <TableBody>
             {rows.map((row) => (
               <TableRow key={row.id}>
-                <TableCell>{row.id + 1}</TableCell>
+                <TableCell>{row.ranking}</TableCell>
                 <TableCell>{row.name}</TableCell>
                 <TableCell>{row.count}</TableCell>
               </TableRow>
@@ -56,6 +75,18 @@ const RankingList: React.FC = () => {
           </TableBody>
         </Table>
       </TableContainer>
+
+      <Stack spacing={2} alignItems="center" sx={{ marginTop: 2 }}>
+        <Pagination
+          count={totalPages}
+          page={page}
+          onChange={handlePageChange}
+          color="primary"
+          size="large"
+          showFirstButton
+          showLastButton
+        />
+      </Stack>
     </Box>
   );
 };

--- a/src/components/RankingList.tsx
+++ b/src/components/RankingList.tsx
@@ -15,7 +15,7 @@ const RankingList: React.FC = () => {
   const [page, setPage] = useState(1);
   const limit = 50; // Users per page
   const skip = (page - 1) * limit;
-  
+
   const rankingQuery = useRanking(skip, limit);
 
   if (rankingQuery.isPending) {
@@ -35,7 +35,7 @@ const RankingList: React.FC = () => {
 
   const totalCount = rankingQuery.data.count;
   const totalPages = Math.ceil(totalCount / limit);
-  
+
   const rows = rankingQuery.data.statistics.map((e, index) => {
     return {
       id: index,
@@ -45,7 +45,10 @@ const RankingList: React.FC = () => {
     };
   });
 
-  const handlePageChange = (event: React.ChangeEvent<unknown>, value: number) => {
+  const handlePageChange = (
+    event: React.ChangeEvent<unknown>,
+    value: number,
+  ) => {
     setPage(value);
   };
 
@@ -54,7 +57,7 @@ const RankingList: React.FC = () => {
       <Typography variant="h6" gutterBottom>
         Total Users: {totalCount}
       </Typography>
-      
+
       <TableContainer>
         <Table>
           <TableHead>


### PR DESCRIPTION
- Update client_wrapper to support skip/limit parameters
- Add Material-UI Pagination component to RankingList
- Display 50 users per page with proper ranking numbers
- Show total user count and page navigation controls
- Regenerate protobuf client code for new API

🤖 Generated with [Claude Code](https://claude.ai/code)