### PR TITLE
Add Discord link to navbar

### DIFF
--- a/src/components/NavBar/index.tsx
+++ b/src/components/NavBar/index.tsx
@@ -6,6 +6,7 @@ import Toolbar from "@mui/material/Toolbar";
 import Menu from "@mui/material/Menu";
 import { GitHub } from "@mui/icons-material";
 import MenuIcon from "@mui/icons-material/Menu";
+import { SvgIcon } from "@mui/material";
 import React from "react";
 import { Link, LinkProps, useNavigate } from "react-router-dom";
 import { useLangContext } from "../../contexts/LangContext";
@@ -17,6 +18,13 @@ import { Drawer, IconButton } from "@mui/material";
 import { useSignOutMutation } from "../../auth/auth";
 
 const ButtonLink = styled(Button)<LinkProps>();
+
+// https://github.com/mui/material-ui/issues/35218#issuecomment-1977984142
+const DiscordIcon: React.FC = () => (
+  <SvgIcon>
+    <path d="M20.317 4.3698a19.7913 19.7913 0 00-4.8851-1.5152.0741.0741 0 00-.0785.0371c-.211.3753-.4447.8648-.6083 1.2495-1.8447-.2762-3.68-.2762-5.4868 0-.1636-.3933-.4058-.8742-.6177-1.2495a.077.077 0 00-.0785-.037 19.7363 19.7363 0 00-4.8852 1.515.0699.0699 0 00-.0321.0277C.5334 9.0458-.319 13.5799.0992 18.0578a.0824.0824 0 00.0312.0561c2.0528 1.5076 4.0413 2.4228 5.9929 3.0294a.0777.0777 0 00.0842-.0276c.4616-.6304.8731-1.2952 1.226-1.9942a.076.076 0 00-.0416-.1057c-.6528-.2476-1.2743-.5495-1.8722-.8923a.077.077 0 01-.0076-.1277c.1258-.0943.2517-.1923.3718-.2914a.0743.0743 0 01.0776-.0105c3.9278 1.7933 8.18 1.7933 12.0614 0a.0739.0739 0 01.0785.0095c.1202.099.246.1981.3728.2924a.077.077 0 01-.0066.1276 12.2986 12.2986 0 01-1.873.8914.0766.0766 0 00-.0407.1067c.3604.698.7719 1.3628 1.225 1.9932a.076.076 0 00.0842.0286c1.961-.6067 3.9495-1.5219 6.0023-3.0294a.077.077 0 00.0313-.0552c.5004-5.177-.8382-9.6739-3.5485-13.6604a.061.061 0 00-.0312-.0286zM8.02 15.3312c-1.1825 0-2.1569-1.0857-2.1569-2.419 0-1.3332.9555-2.4189 2.157-2.4189 1.2108 0 2.1757 1.0952 2.1568 2.419-.0190 1.3332-.9555 2.4189-2.1569 2.4189zm7.9748 0c-1.1825 0-2.1569-1.0857-2.1569-2.419 0-1.3332.9554-2.4189 2.1569-2.4189 1.2108 0 2.1757 1.0952 2.1568 2.419 0 1.3332-.9460 2.4189-2.1568 2.4189Z" />
+  </SvgIcon>
+);
 
 const NavBar: React.FC = () => {
   const title = (
@@ -107,6 +115,14 @@ const NavBarElements: React.FC = () => {
       {/* right side */}
       <LangSelect />
       {UserMenu()}
+      <Button
+        color="inherit"
+        href="https://discord.gg/DfJvTe5tzD"
+        target="_blank"
+        rel="noopener"
+      >
+        <DiscordIcon />
+      </Button>
       <Button
         color="inherit"
         href="https://github.com/yosupo06/library-checker-problems"


### PR DESCRIPTION
## Summary
- Add Discord community link to the navbar alongside existing GitHub link
- Implement custom Discord SVG icon using Material-UI SvgIcon component  
- Position Discord link before GitHub link for better visibility
- Maintain responsive design for both desktop and mobile layouts

## Changes
- Import `SvgIcon` from Material-UI for custom icon support
- Create `DiscordIcon` component with official Discord logo SVG path
- Add Discord button with link to `https://discord.gg/DfJvTe5tzD` (from GitHub repo)
- Maintain consistent styling and security attributes (`target="_blank"`, `rel="noopener"`)

## Test plan
- [x] Verify Discord link opens in new tab
- [x] Confirm icon displays correctly in both desktop and mobile views
- [x] Check navbar responsive behavior is maintained
- [x] Validate ESLint and Prettier checks pass

🤖 Generated with [Claude Code](https://claude.ai/code)