### PR TITLE
Fix Tools menu not closing after navigation

### DIFF
--- a/src/components/NavBar/index.tsx
+++ b/src/components/NavBar/index.tsx
@@ -203,10 +203,10 @@ const ToolsMenu: React.FC = () => {
         open={Boolean(anchorEl)}
         onClose={handleClose}
       >
-        <MenuItem>
+        <MenuItem onClick={handleClose}>
           <NavbarLink to={`/tool/statementviewer`}>Statement Viewer</NavbarLink>
         </MenuItem>
-        <MenuItem>
+        <MenuItem onClick={handleClose}>
           <NavbarLink to={`/tool/monitoring`}>Monitoring</NavbarLink>
         </MenuItem>
       </Menu>


### PR DESCRIPTION
## Summary
- Fix issue where Tools submenu stays open after selecting menu items
- Add proper onClick handlers to close menu when navigating

## Problem
The Tools menu in the navbar would remain open after clicking on submenu items (Statement Viewer, Monitoring), causing poor UX as users had to manually click elsewhere to close it.

## Solution
- Add `onClick={handleClose}` to both MenuItem components in ToolsMenu
- Ensures menu automatically closes when user selects any submenu option
- Maintains consistent behavior with other dropdown menus

## Test plan
- [x] Click Tools menu to open submenu
- [x] Click "Statement Viewer" - verify menu closes and page navigates
- [x] Click Tools menu again, click "Monitoring" - verify menu closes and page navigates
- [x] Test behavior is consistent across desktop and mobile views

🤖 Generated with [Claude Code](https://claude.ai/code)