### PR TITLE
Upgrade Monaco Editor from v0.31.1 to v0.52.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "grpc-web": "~1.2.1",
         "katex": "^0.16.11",
         "liquidjs": "^10.9.4",
-        "monaco-editor": "^0.31.1",
+        "monaco-editor": "^0.52.2",
         "prettier": "^3.3.3",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -6155,9 +6155,10 @@
       }
     },
     "node_modules/monaco-editor": {
-      "version": "0.31.1",
-      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.31.1.tgz",
-      "integrity": "sha512-FYPwxGZAeP6mRRyrr5XTGHD9gRXVjy7GUzF4IPChnyt3fS5WrNxIkS8DNujWf6EQy0Zlzpxw8oTVE+mWI2/D1Q=="
+      "version": "0.52.2",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.52.2.tgz",
+      "integrity": "sha512-GEQWEZmfkOGLdd3XK8ryrfWz3AIP8YymVXiPHEdewrUq7mh0qrKrfHLNCXcbB6sTnMLnOZ3ztSiKcciFUkIJwQ==",
+      "license": "MIT"
     },
     "node_modules/mri": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "grpc-web": "~1.2.1",
     "katex": "^0.16.11",
     "liquidjs": "^10.9.4",
-    "monaco-editor": "^0.31.1",
+    "monaco-editor": "^0.52.2",
     "prettier": "^3.3.3",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/src/components/SourceEditor.tsx
+++ b/src/components/SourceEditor.tsx
@@ -10,6 +10,7 @@ interface Props {
   onChange?: (value: string) => void;
   readOnly: boolean;
   height?: number;
+  placeholder?: string;
 }
 
 const editorMode = (lang?: string) => {
@@ -52,7 +53,7 @@ const editorMode = (lang?: string) => {
 const MIN_EDITOR_HEIGHT = 100;
 
 const SourceEditor: React.FC<Props> = (props) => {
-  const { value, language, onChange, readOnly, height } = props;
+  const { value, language, onChange, readOnly, height, placeholder } = props;
   const [editorHeight, setEditorHeight] = useState(height ?? MIN_EDITOR_HEIGHT);
 
   const mode = editorMode(language);
@@ -82,6 +83,7 @@ const SourceEditor: React.FC<Props> = (props) => {
           readOnly: readOnly,
           scrollBeyondLastColumn: 0,
           scrollBeyondLastLine: false,
+          placeholder: placeholder,
           minimap: {
             enabled: false,
           },

--- a/src/pages/Hack.tsx
+++ b/src/pages/Hack.tsx
@@ -80,6 +80,7 @@ const Hack: React.FC = () => {
               }}
               readOnly={false}
               height={600}
+              placeholder="Enter test case input data..."
             />
             <Typography variant="caption">
               Max length: 1MiB(=2<sup>20</sup>Byte)
@@ -96,6 +97,7 @@ const Hack: React.FC = () => {
               readOnly={false}
               language="cpp"
               height={600}
+              placeholder="Enter C++ test generator code..."
             />
             <Typography variant="caption">
               Max length: 1MiB(=2<sup>20</sup>Byte)

--- a/src/pages/ProblemInfo.tsx
+++ b/src/pages/ProblemInfo.tsx
@@ -365,6 +365,7 @@ const SubmitForm: React.FC<{ problemId: string }> = (props) => {
               }}
               readOnly={false}
               height={400}
+              placeholder="Enter your solution code here..."
             />
           </FormControl>
 


### PR DESCRIPTION
## Summary
- Upgraded Monaco Editor dependency from v0.31.1 to v0.52.2 (major version upgrade)
- Added placeholder prop support to SourceEditor component for improved UX
- Enhanced code editor experience with helpful placeholder text throughout the application

## Test plan
- [x] All existing tests pass (10/10)
- [x] ESLint passes with zero warnings  
- [x] Production build succeeds
- [x] Code editors render correctly
- [x] Placeholder text displays appropriately in submission forms
- [x] Monaco Editor functionality works as expected

🤖 Generated with [Claude Code](https://claude.ai/code)