### PR TITLE
Add pre-commit hooks: run Prettier and ESLint on commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,16 +2,12 @@ repos:
   - repo: local
     hooks:
       - id: prettier-check
-        name: prettier check (src)
+        name: prettier check
         language: system
         entry: npm run prettier:check
         pass_filenames: false
-        files: ^src/.*\.(ts|tsx|js|jsx)$
-        stages: [commit]
       - id: eslint-lint
-        name: eslint lint (src)
+        name: eslint lint
         language: system
         entry: npm run lint
         pass_filenames: false
-        files: ^src/.*\.(ts|tsx|js|jsx)$
-        stages: [commit]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,17 @@
+repos:
+  - repo: local
+    hooks:
+      - id: prettier-check
+        name: prettier check (src)
+        language: system
+        entry: npm run prettier:check
+        pass_filenames: false
+        files: ^src/.*\.(ts|tsx|js|jsx)$
+        stages: [commit]
+      - id: eslint-lint
+        name: eslint lint (src)
+        language: system
+        entry: npm run lint
+        pass_filenames: false
+        files: ^src/.*\.(ts|tsx|js|jsx)$
+        stages: [commit]

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ npm run dev -- --mode production
 1. pre-commit をインストール: `pip install pre-commit`
 2. Git フックを有効化: `pre-commit install`
 
-以後、`src/**/*.ts(x)|js(x)` に変更があるコミットでは以下を実行し、失敗時はコミットが中断されます。
+以後、コミット時に常に以下を実行し、失敗時はコミットを中断します。
 - `npm run prettier:check`
 - `npm run lint`
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,17 @@ npm run dev -- --mode production
 
 なんでも歓迎
 
+### pre-commit hooks
+
+このリポジトリはコミット前に Prettier/ESLint を実行する pre-commit をサポートします。
+
+1. pre-commit をインストール: `pip install pre-commit`
+2. Git フックを有効化: `pre-commit install`
+
+以後、`src/**/*.ts(x)|js(x)` に変更があるコミットでは以下を実行し、失敗時はコミットが中断されます。
+- `npm run prettier:check`
+- `npm run lint`
+
 ## library-checker-project
 
 - problems: [library-checker-problems](https://github.com/yosupo06/library-checker-problems)


### PR DESCRIPTION
This PR introduces pre-commit hooks that enforce code style locally.

- Add `.pre-commit-config.yaml` to run `npm run prettier:check` and `npm run lint` on every commit
- Update README with setup instructions (`pip install pre-commit && pre-commit install`)

No code changes beyond config/docs.
