### PR TITLE
feat(frontend): switch problems/ranking to REST via openapi-fetch\n\n…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "katex": "^0.16.11",
         "liquidjs": "^10.9.4",
         "monaco-editor": "^0.52.2",
+        "openapi-fetch": "^0.12.2",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-hook-form": "^7.43.9",
@@ -6384,6 +6385,15 @@
         "wrappy": "1"
       }
     },
+    "node_modules/openapi-fetch": {
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/openapi-fetch/-/openapi-fetch-0.12.5.tgz",
+      "integrity": "sha512-FnAMWLt0MNL6ComcL4q/YbB1tUgyz5YnYtwA1+zlJ5xcucmK5RlWsgH1ynxmEeu8fGJkYjm8armU/HVpORc9lw==",
+      "license": "MIT",
+      "dependencies": {
+        "openapi-typescript-helpers": "^0.0.15"
+      }
+    },
     "node_modules/openapi-typescript": {
       "version": "6.7.6",
       "resolved": "https://registry.npmjs.org/openapi-typescript/-/openapi-typescript-6.7.6.tgz",
@@ -6401,6 +6411,12 @@
       "bin": {
         "openapi-typescript": "bin/cli.js"
       }
+    },
+    "node_modules/openapi-typescript-helpers": {
+      "version": "0.0.15",
+      "resolved": "https://registry.npmjs.org/openapi-typescript-helpers/-/openapi-typescript-helpers-0.0.15.tgz",
+      "integrity": "sha512-opyTPaunsklCBpTK8JGef6mfPhLSnyy5a0IN9vKtx3+4aExf+KxEqYwIy3hqkedXIB97u357uLMJsOnm3GVjsw==",
+      "license": "MIT"
     },
     "node_modules/openapi-typescript/node_modules/supports-color": {
       "version": "9.4.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "remark-parse": "^11.0.0",
     "remark-rehype": "^11.1.2",
     "unified": "^11.0.5",
-    "url-join": "^5.0.0"
+    "url-join": "^5.0.0",
+    "openapi-fetch": "^0.12.2"
   },
   "scripts": {
     "dev": "vite --host",

--- a/src/api/client_wrapper.ts
+++ b/src/api/client_wrapper.ts
@@ -17,9 +17,6 @@ import {
   LangListResponse,
   MonitoringResponse,
   ProblemCategoriesResponse,
-  ProblemInfoResponse,
-  ProblemListResponse,
-  RankingResponse,
   RejudgeRequest,
   SubmissionInfoResponse,
   SubmissionListResponse,
@@ -28,7 +25,12 @@ import {
   UserInfoResponse,
 } from "../proto/library_checker";
 import { useIdToken } from "../auth/auth";
-import { fetchRanking } from "./http_client";
+import {
+  fetchRanking,
+  fetchProblemInfo,
+  fetchProblemList,
+} from "./http_client";
+import type { components as OpenApi } from "../openapi/types";
 
 const currentUserKey = ["api", "currentUser"];
 export const useCurrentUser = () => {
@@ -88,12 +90,11 @@ export const useLangList = (): UseQueryResult<LangListResponse> =>
 export const useRanking = (
   skip: number = 0,
   limit: number = 100,
-): UseQueryResult<RankingResponse> =>
+): UseQueryResult<OpenApi["schemas"]["RankingResponse"]> =>
   useQuery({
     queryKey: ["ranking", skip, limit],
     // Use REST for migrated endpoint
-    queryFn: async () =>
-      (await fetchRanking(skip, limit)) as unknown as RankingResponse,
+    queryFn: async () => await fetchRanking(skip, limit),
   });
 
 export const useMonitoring = (): UseQueryResult<MonitoringResponse> =>
@@ -105,17 +106,21 @@ export const useMonitoring = (): UseQueryResult<MonitoringResponse> =>
 
 export const useProblemInfo = (
   name: string,
-): UseQueryResult<ProblemInfoResponse> =>
+): UseQueryResult<OpenApi["schemas"]["ProblemInfoResponse"]> =>
   useQuery({
     queryKey: ["problemInfo", name],
-    queryFn: async () => await client.problemInfo({ name: name }, {}).response,
+    // Use REST endpoint
+    queryFn: async () => await fetchProblemInfo(name),
     structuralSharing: false,
   });
 
-export const useProblemList = (): UseQueryResult<ProblemListResponse> =>
+export const useProblemList = (): UseQueryResult<
+  OpenApi["schemas"]["ProblemListResponse"]
+> =>
   useQuery({
     queryKey: ["problemList"],
-    queryFn: async () => await client.problemList({}, {}).response,
+    // Use REST endpoint
+    queryFn: async () => await fetchProblemList(),
   });
 
 export const useProblemCategories =

--- a/src/components/ProblemList.tsx
+++ b/src/components/ProblemList.tsx
@@ -5,13 +5,13 @@ import TableCell from "@mui/material/TableCell";
 import TableContainer from "@mui/material/TableContainer";
 import TableRow from "@mui/material/TableRow";
 import React from "react";
-import { Problem } from "../proto/library_checker";
+import type { components as OpenApi } from "../openapi/types";
 import { Link } from "react-router-dom";
 import { lightGreen, cyan } from "@mui/material/colors";
 import KatexTypography from "./katex/KatexTypography";
 import { styled } from "@mui/material/styles";
 interface Props {
-  problems: Problem[];
+  problems: OpenApi["schemas"]["Problem"][];
   solvedStatus?: {
     [problem: string]: "latest_ac" | "ac" | "unknown";
   };

--- a/src/openapi/types.ts
+++ b/src/openapi/types.ts
@@ -8,6 +8,14 @@ export interface paths {
     /** Get ranking */
     get: operations["getRanking"];
   };
+  "/problems": {
+    /** Get problems */
+    get: operations["getProblems"];
+  };
+  "/problems/{name}": {
+    /** Get problem info */
+    get: operations["getProblemInfo"];
+  };
 }
 
 export type webhooks = Record<string, never>;
@@ -23,6 +31,22 @@ export interface components {
       statistics: components["schemas"]["UserStatistics"][];
       /** Format: int32 */
       count: number;
+    };
+    Problem: {
+      name: string;
+      title: string;
+    };
+    ProblemListResponse: {
+      problems: components["schemas"]["Problem"][];
+    };
+    ProblemInfoResponse: {
+      title: string;
+      source_url: string;
+      /** Format: float */
+      time_limit: number;
+      version: string;
+      testcases_version: string;
+      overall_version: string;
     };
   };
   responses: never;
@@ -50,6 +74,33 @@ export interface operations {
       200: {
         content: {
           "application/json": components["schemas"]["RankingResponse"];
+        };
+      };
+    };
+  };
+  /** Get problems */
+  getProblems: {
+    responses: {
+      /** @description OK */
+      200: {
+        content: {
+          "application/json": components["schemas"]["ProblemListResponse"];
+        };
+      };
+    };
+  };
+  /** Get problem info */
+  getProblemInfo: {
+    parameters: {
+      path: {
+        name: string;
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        content: {
+          "application/json": components["schemas"]["ProblemInfoResponse"];
         };
       };
     };

--- a/src/pages/ProblemInfo.tsx
+++ b/src/pages/ProblemInfo.tsx
@@ -19,7 +19,7 @@ import {
   useProblemInfo,
   useSubmitMutation,
 } from "../api/client_wrapper";
-import { ProblemInfoResponse } from "../proto/library_checker";
+import type { components as OpenApi } from "../openapi/types";
 import SourceEditor from "../components/SourceEditor";
 import { GitHub, FlashOn, Person, Forum } from "@mui/icons-material";
 import { useTranslation } from "../utils/translations";
@@ -76,7 +76,7 @@ const baseURL = new URL(import.meta.env.VITE_PUBLIC_BUCKET_URL);
 
 const ProblemInfoBody: React.FC<{
   problemId: string;
-  problemInfo: ProblemInfoResponse;
+  problemInfo: OpenApi["schemas"]["ProblemInfoResponse"];
 }> = (props) => {
   const { problemId, problemInfo } = props;
 
@@ -101,7 +101,7 @@ const ProblemInfoBody: React.FC<{
   return (
     <Box>
       <Typography variant="body1" paragraph={true}>
-        Time Limit: {problemInfo.timeLimit} sec
+        Time Limit: {problemInfo.time_limit} sec
       </Typography>
 
       <UsefulLinks
@@ -147,7 +147,7 @@ export const StatementBody: React.FC<{
 };
 
 const UsefulLinks: React.FC<{
-  problemInfo: ProblemInfoResponse;
+  problemInfo: OpenApi["schemas"]["ProblemInfoResponse"];
   problemId: string;
   infoToml: ProblemInfoToml;
 }> = (props) => {
@@ -185,7 +185,7 @@ const UsefulLinks: React.FC<{
       >
         Fastest
       </LinkButton>
-      <ExternalLinkButton startIcon={<GitHub />} href={problemInfo.sourceUrl}>
+      <ExternalLinkButton startIcon={<GitHub />} href={problemInfo.source_url}>
         GitHub
       </ExternalLinkButton>
       {infoToml.forum && (

--- a/src/utils/problem.categorizer.ts
+++ b/src/utils/problem.categorizer.ts
@@ -1,21 +1,21 @@
-import { Problem, ProblemCategory } from "../proto/library_checker";
+import type { ProblemCategory } from "../proto/library_checker";
+import type { components as OpenApi } from "../openapi/types";
 
 export type CategorisedProblems = {
   name: string;
-  problems: Problem[];
+  problems: OpenApi["schemas"]["Problem"][];
 }[];
 
 export const categoriseProblems = (
-  problems: Problem[],
+  problems: OpenApi["schemas"]["Problem"][],
   categories: ProblemCategory[],
 ): CategorisedProblems => {
-  const nameToProblem = problems.reduce<{ [name: string]: Problem }>(
-    (dict, problem) => {
-      dict[problem.name] = problem;
-      return dict;
-    },
-    {},
-  );
+  const nameToProblem = problems.reduce<{
+    [name: string]: OpenApi["schemas"]["Problem"];
+  }>((dict, problem) => {
+    dict[problem.name] = problem;
+    return dict;
+  }, {});
 
   const problemNames = problems.map((e) => e.name);
   const problemNameSet = new Set(problemNames);

--- a/src/utils/problem.storage.ts
+++ b/src/utils/problem.storage.ts
@@ -73,7 +73,7 @@ export const toProblemVersion = (
 });
 import { useQuery, useQueries } from "@tanstack/react-query";
 import { parseProblemInfoToml, type ProblemInfoToml } from "./problem.info";
-import type { ProblemInfoResponse } from "../proto/library_checker";
+import type { components as OpenApi } from "../openapi/types";
 
 export type ProblemAssets = {
   info?: ProblemInfoToml;
@@ -87,12 +87,12 @@ export type ProblemAssets = {
 export const useProblemAssets = (
   baseURL: URL,
   problemId: string,
-  problemInfo: ProblemInfoResponse,
+  problemInfo: OpenApi["schemas"]["ProblemInfoResponse"],
 ): ProblemAssets => {
   const pv = toProblemVersion(problemId, {
     version: problemInfo.version,
-    overallVersion: problemInfo.overallVersion,
-    testcasesVersion: problemInfo.testcasesVersion,
+    overallVersion: problemInfo.overall_version,
+    testcasesVersion: problemInfo.testcases_version,
   });
 
   const infoTomlQ = useQuery({


### PR DESCRIPTION
…- Use openapi-fetch createClient<paths>() with OpenAPI types\n- Remove proto casts & custom REST types\n- Enforce VITE_REST_API_URL (no fallback)\n- Update hooks/components to snake_case fields where needed\n- Keep gRPC for non-migrated endpoints\n\nBuild & lint pass locally.