### PR TITLE
feat(frontend): use REST for LangList and ProblemCategories; add client functions; regenerate OpenAPI types; format

### DIFF
--- a/src/api/client_wrapper.ts
+++ b/src/api/client_wrapper.ts
@@ -14,9 +14,7 @@ import {
   HackListResponse,
   HackRequest,
   HackResponse,
-  LangListResponse,
   MonitoringResponse,
-  ProblemCategoriesResponse,
   RejudgeRequest,
   SubmissionInfoResponse,
   SubmissionListResponse,
@@ -29,6 +27,8 @@ import {
   fetchRanking,
   fetchProblemInfo,
   fetchProblemList,
+  fetchLangList,
+  fetchProblemCategories,
 } from "./http_client";
 import type { components as OpenApi } from "../openapi/types";
 
@@ -81,10 +81,13 @@ const transport = new GrpcWebFetchTransport({
 const client = new LibraryCheckerServiceClient(transport);
 export default client;
 
-export const useLangList = (): UseQueryResult<LangListResponse> =>
+export const useLangList = (): UseQueryResult<
+  OpenApi["schemas"]["LangListResponse"]
+> =>
   useQuery({
     queryKey: ["langList"],
-    queryFn: async () => await client.langList({}, {}).response,
+    // Use REST endpoint
+    queryFn: async () => await fetchLangList(),
   });
 
 export const useRanking = (
@@ -123,12 +126,14 @@ export const useProblemList = (): UseQueryResult<
     queryFn: async () => await fetchProblemList(),
   });
 
-export const useProblemCategories =
-  (): UseQueryResult<ProblemCategoriesResponse> =>
-    useQuery({
-      queryKey: ["problemCategories"],
-      queryFn: async () => await client.problemCategories({}, {}).response,
-    });
+export const useProblemCategories = (): UseQueryResult<
+  OpenApi["schemas"]["ProblemCategoriesResponse"]
+> =>
+  useQuery({
+    queryKey: ["problemCategories"],
+    // Use REST endpoint
+    queryFn: async () => await fetchProblemCategories(),
+  });
 
 export const useUserInfo = (
   name: string,

--- a/src/api/http_client.ts
+++ b/src/api/http_client.ts
@@ -48,4 +48,18 @@ export async function fetchProblemInfo(
   return unwrap<components["schemas"]["ProblemInfoResponse"]>(r);
 }
 
+export async function fetchLangList(): Promise<
+  components["schemas"]["LangListResponse"]
+> {
+  const r = await client.GET("/langs");
+  return unwrap<components["schemas"]["LangListResponse"]>(r);
+}
+
+export async function fetchProblemCategories(): Promise<
+  components["schemas"]["ProblemCategoriesResponse"]
+> {
+  const r = await client.GET("/categories");
+  return unwrap<components["schemas"]["ProblemCategoriesResponse"]>(r);
+}
+
 export type {};

--- a/src/openapi/types.ts
+++ b/src/openapi/types.ts
@@ -16,6 +16,14 @@ export interface paths {
     /** Get problem info */
     get: operations["getProblemInfo"];
   };
+  "/langs": {
+    /** Get language list */
+    get: operations["getLangList"];
+  };
+  "/categories": {
+    /** Get problem categories */
+    get: operations["getProblemCategories"];
+  };
 }
 
 export type webhooks = Record<string, never>;
@@ -47,6 +55,21 @@ export interface components {
       version: string;
       testcases_version: string;
       overall_version: string;
+    };
+    Lang: {
+      id: string;
+      name: string;
+      version: string;
+    };
+    LangListResponse: {
+      langs: components["schemas"]["Lang"][];
+    };
+    ProblemCategory: {
+      title: string;
+      problems: string[];
+    };
+    ProblemCategoriesResponse: {
+      categories: components["schemas"]["ProblemCategory"][];
     };
   };
   responses: never;
@@ -101,6 +124,28 @@ export interface operations {
       200: {
         content: {
           "application/json": components["schemas"]["ProblemInfoResponse"];
+        };
+      };
+    };
+  };
+  /** Get language list */
+  getLangList: {
+    responses: {
+      /** @description OK */
+      200: {
+        content: {
+          "application/json": components["schemas"]["LangListResponse"];
+        };
+      };
+    };
+  };
+  /** Get problem categories */
+  getProblemCategories: {
+    responses: {
+      /** @description OK */
+      200: {
+        content: {
+          "application/json": components["schemas"]["ProblemCategoriesResponse"];
         };
       };
     };


### PR DESCRIPTION
Summary
- Switch LangList and ProblemCategories queries to REST.
- Add REST client functions fetchLangList() and fetchProblemCategories().
- Regenerate OpenAPI types and wire hooks to use openapi-fetch client.

Motivation
- Align with REST migration; reduce gRPC calls on UI for read-only data.

Changes
- src/api/http_client.ts: add client fns for /langs and /categories.
- src/api/client_wrapper.ts: update useLangList() and useProblemCategories() to REST and OpenAPI types.
- src/openapi/types.ts: regenerated.

How to run locally
- npm install
- npm run openapi:gen (ensures types in sync)
- npm run build
- npm run test (optional)

Results
- Build passes locally; components using these hooks continue to render with the same fields.

Backend dependency
- Requires REST API from yosupo06/library-checker-judge#525

Notes
- Uses VITE_REST_API_URL for base; staging/prod .env already set.
