### PR TITLE
feat: migrate submissions to rest api

### DIFF
--- a/src/api/client_wrapper.ts
+++ b/src/api/client_wrapper.ts
@@ -17,8 +17,10 @@ import {
   HackResponse,
   MonitoringResponse,
   RejudgeRequest,
+  SubmissionCaseResult,
   SubmissionInfoResponse,
   SubmissionListResponse,
+  SubmissionOverview,
   SubmitRequest,
   SubmitResponse,
   UserInfoResponse,
@@ -34,8 +36,12 @@ import {
   registerUser,
   patchCurrentUserInfo,
   fetchUserInfo as fetchUserInfoREST,
+  fetchSubmissionList,
+  fetchSubmissionInfo,
+  postSubmit,
 } from "./http_client";
 import type { components as OpenApi } from "../openapi/types";
+import { Timestamp as TimestampMessage } from "../proto/google/protobuf/timestamp";
 
 const currentUserKey = ["api", "currentUser"];
 export const useCurrentUser = () => {
@@ -194,21 +200,24 @@ export const useSubmissionList = (
       limit,
     ],
     // Use REST endpoint
-    queryFn: async () =>
-      await client.submissionList(
-        {
-          problem: problem,
-          user: user,
-          dedupUser: dedupUser,
-          status: status,
-          lang: lang,
-          order: order,
-          skip: skip,
-          limit: limit,
-          hacked: false,
-        },
-        {},
-      ).response,
+    queryFn: async () => {
+      const orderParam =
+        order === "-id" || order === "+time" ? order : undefined;
+      const res = await fetchSubmissionList({
+        problem,
+        user,
+        dedupUser,
+        status,
+        lang,
+        order: orderParam,
+        skip,
+        limit,
+      });
+      return {
+        submissions: res.submissions.map(toSubmissionOverviewProto),
+        count: res.count,
+      } satisfies SubmissionListResponse;
+    },
     structuralSharing: false,
   });
 
@@ -219,16 +228,12 @@ export const useSubmissionInfo = (
     "queryKey" | "queryFn"
   >,
 ): UseQueryResult<SubmissionInfoResponse> => {
-  const bearer = useBearer();
   return useQuery({
     queryKey: ["submissionInfo", String(id)],
-    queryFn: async () =>
-      await client.submissionInfo(
-        {
-          id: id,
-        },
-        bearer.data ?? undefined,
-      ).response,
+    queryFn: async () => {
+      const res = await fetchSubmissionInfo(id);
+      return toSubmissionInfoProto(res);
+    },
     structuralSharing: false,
     ...options,
   });
@@ -240,10 +245,20 @@ export const useSubmitMutation = (
     "mutationFn"
   >,
 ) => {
-  const bearer = useBearer();
+  const idToken = useIdToken();
   return useMutation({
-    mutationFn: async (req: SubmitRequest) =>
-      await client.submit(req, bearer.data ?? undefined).response,
+    mutationFn: async (req: SubmitRequest) => {
+      const res = await postSubmit(
+        {
+          problem: req.problem,
+          source: req.source,
+          lang: req.lang,
+          tleKnockout: req.tleKnockout,
+        },
+        idToken.data ?? undefined,
+      );
+      return { id: res.id } satisfies SubmitResponse;
+    },
     ...options,
   });
 };
@@ -254,6 +269,81 @@ export const useRejudgeMutation = () => {
     mutationFn: async (req: RejudgeRequest) =>
       await client.rejudge(req, bearer.data ?? undefined).response,
   });
+};
+
+const toSubmissionInfoProto = (
+  res: OpenApi["schemas"]["SubmissionInfoResponse"],
+): SubmissionInfoResponse => {
+  const overview = toSubmissionOverviewProto(res.overview);
+  const caseResults = res.case_results?.map(toSubmissionCaseResultProto) ?? [];
+  return {
+    overview,
+    caseResults,
+    source: res.source,
+    compileError: decodeBase64(res.compile_error),
+    canRejudge: res.can_rejudge,
+  } satisfies SubmissionInfoResponse;
+};
+
+const toSubmissionOverviewProto = (
+  overview: OpenApi["schemas"]["SubmissionOverview"],
+): SubmissionOverview => {
+  return {
+    id: overview.id,
+    problemName: overview.problem_name,
+    problemTitle: overview.problem_title,
+    userName: overview.user_name ?? "",
+    lang: overview.lang,
+    isLatest: overview.is_latest,
+    status: overview.status,
+    hacked: false,
+    time: overview.time,
+    memory: BigInt(overview.memory),
+    submissionTime: overview.submission_time
+      ? TimestampMessage.fromDate(new Date(overview.submission_time))
+      : undefined,
+  } satisfies SubmissionOverview;
+};
+
+const toSubmissionCaseResultProto = (
+  res: OpenApi["schemas"]["SubmissionCaseResult"],
+): SubmissionCaseResult => {
+  return {
+    case: res.case,
+    status: res.status,
+    time: res.time,
+    memory: BigInt(res.memory),
+    stderr: decodeBase64(res.stderr),
+    checkerOut: decodeBase64(res.checker_out),
+  } satisfies SubmissionCaseResult;
+};
+
+const decodeBase64 = (value?: string | null): Uint8Array => {
+  if (!value) {
+    return new Uint8Array();
+  }
+  const globalAtob = (
+    globalThis as {
+      atob?: (data: string) => string;
+    }
+  ).atob;
+  if (typeof globalAtob === "function") {
+    const binary = globalAtob(value);
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i += 1) {
+      bytes[i] = binary.charCodeAt(i);
+    }
+    return bytes;
+  }
+  const globalBuffer = (
+    globalThis as {
+      Buffer?: { from: (data: string, encoding: string) => Uint8Array };
+    }
+  ).Buffer;
+  if (globalBuffer) {
+    return globalBuffer.from(value, "base64");
+  }
+  throw new Error("Base64 decoder is not available in this environment");
 };
 
 const useBearer = () => {

--- a/src/api/http_client.ts
+++ b/src/api/http_client.ts
@@ -108,17 +108,13 @@ export async function fetchUserInfo(
   return unwrap<components["schemas"]["UserInfoResponse"]>(r);
 }
 
-export async function patchUserInfo(
+export async function fetchUserStatistics(
   name: string,
-  user: components["schemas"]["User"],
-  idToken?: string | null,
-): Promise<components["schemas"]["ChangeUserInfoResponse"]> {
-  const r = await client.PATCH("/users/{name}", {
+): Promise<components["schemas"]["UserSolvedStatisticsResponse"]> {
+  const r = await client.GET("/users/{name}/statistics", {
     params: { path: { name } },
-    body: { user },
-    headers: authHeaders(idToken),
   });
-  return unwrap<components["schemas"]["ChangeUserInfoResponse"]>(r);
+  return unwrap<components["schemas"]["UserSolvedStatisticsResponse"]>(r);
 }
 
 // Submissions
@@ -135,7 +131,7 @@ export type SubmissionListQuery = {
   dedupUser?: boolean;
   status?: string;
   lang?: string;
-  order?: string;
+  order?: components["schemas"]["SubmissionOrder"];
   skip?: number;
   limit?: number;
 };

--- a/src/api/http_client.ts
+++ b/src/api/http_client.ts
@@ -129,6 +129,70 @@ export type SubmitPayload = {
   tleKnockout?: boolean;
 };
 
-// Note: submission endpoints remain gRPC for now
+export type SubmissionListQuery = {
+  problem?: string;
+  user?: string;
+  dedupUser?: boolean;
+  status?: string;
+  lang?: string;
+  order?: string;
+  skip?: number;
+  limit?: number;
+};
+
+type SubmissionListQueryParams = NonNullable<
+  paths["/submissions"]["get"]["parameters"]["query"]
+>;
+
+const dropUndefined = <T extends Record<string, unknown>>(obj: T): T => {
+  return Object.fromEntries(
+    Object.entries(obj).filter(([, value]) => value !== undefined),
+  ) as T;
+};
+
+export async function postSubmit(
+  payload: SubmitPayload,
+  idToken?: string | null,
+): Promise<components["schemas"]["SubmitResponse"]> {
+  const body = dropUndefined<components["schemas"]["SubmitRequest"]>({
+    problem: payload.problem,
+    source: payload.source,
+    lang: payload.lang,
+    tle_knockout: payload.tleKnockout,
+  });
+  const r = await client.POST("/submit", {
+    body,
+    headers: authHeaders(idToken),
+  });
+  return unwrap<components["schemas"]["SubmitResponse"]>(r);
+}
+
+export async function fetchSubmissionList(
+  query: SubmissionListQuery,
+): Promise<components["schemas"]["SubmissionListResponse"]> {
+  const params = dropUndefined<SubmissionListQueryParams>({
+    skip: query.skip,
+    limit: query.limit,
+    problem: query.problem,
+    status: query.status,
+    user: query.user,
+    dedupUser: query.dedupUser,
+    lang: query.lang,
+    order: query.order,
+  });
+  const r = await client.GET("/submissions", {
+    params: { query: params },
+  });
+  return unwrap<components["schemas"]["SubmissionListResponse"]>(r);
+}
+
+export async function fetchSubmissionInfo(
+  id: number,
+): Promise<components["schemas"]["SubmissionInfoResponse"]> {
+  const r = await client.GET("/submissions/{id}", {
+    params: { path: { id } },
+  });
+  return unwrap<components["schemas"]["SubmissionInfoResponse"]>(r);
+}
 
 export type {};


### PR DESCRIPTION
## Summary
- switch submission data to fetch from REST endpoints
- convert REST payloads into proto-shaped objects for existing consumers
- add helpers for POST /submit and GET /submissions endpoints

## Testing
- npm run build