### PR TITLE
fix: show login progress and errors

### DIFF
--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -21,6 +21,7 @@ const Login: React.FC = () => {
   const signInMutation = useSignInMutation();
   const onSignIn = (e: React.FormEvent) => {
     e.preventDefault();
+    if (signInMutation.isPending) return;
     signInMutation.mutate(
       {
         email: email,
@@ -42,6 +43,11 @@ const Login: React.FC = () => {
         <code>yosupo@dummy.judge.yosupo.jp</code>
       </Alert>
       <form onSubmit={(e) => onSignIn(e)}>
+        {signInMutation.isError && (
+          <Alert severity="error">
+            {(signInMutation.error as Error).message}
+          </Alert>
+        )}
         <div>
           <TextField
             required
@@ -49,6 +55,7 @@ const Login: React.FC = () => {
             value={email}
             onChange={(e) => setEmail(e.target.value)}
             style={{ width: 300 }}
+            disabled={signInMutation.isPending}
           />
         </div>
         <div>
@@ -59,10 +66,15 @@ const Login: React.FC = () => {
             value={password}
             onChange={(e) => setPassword(e.target.value)}
             style={{ width: 300 }}
+            disabled={signInMutation.isPending}
           />
         </div>
-        <Button color="primary" type="submit">
-          Login
+        <Button
+          color="primary"
+          type="submit"
+          disabled={signInMutation.isPending}
+        >
+          {signInMutation.isPending ? "Logging in..." : "Login"}
         </Button>
       </form>
       <PasswordReset />


### PR DESCRIPTION
## Summary
- Disable login form fields and submit button while sign-in is pending
- Show a `Logging in...` button label during sign-in
- Display Firebase sign-in errors on the login page

## Testing
- `npm run prettier -- src/pages/Login.tsx`
- `npm run build` *(fails: existing `src/api/http_client.ts(255,32)` type error in unrelated local changes)*
- `npm run lint` *(fails: existing `src/api/http_client.ts(218,12)` `Buffer` no-undef in unrelated local changes)*