### PR TITLE
feat(frontend): migrate hack hooks to REST

### DIFF
--- a/src/api/client_wrapper.ts
+++ b/src/api/client_wrapper.ts
@@ -15,6 +15,7 @@ import {
   HackListResponse,
   HackRequest,
   HackResponse,
+  HackOverview,
   MonitoringResponse,
   RejudgeRequest,
   SubmissionCaseResult,
@@ -41,6 +42,9 @@ import {
   fetchSubmissionList,
   fetchSubmissionInfo,
   postSubmit,
+  fetchHackInfo,
+  fetchHackList,
+  postHack,
 } from "./http_client";
 import type { components as OpenApi } from "../openapi/types";
 import { Timestamp as TimestampMessage } from "../proto/google/protobuf/timestamp";
@@ -397,10 +401,19 @@ export const useHackMutation = (
     "mutationFn"
   >,
 ) => {
-  const bearer = useBearer();
+  const idToken = useIdToken();
   return useMutation({
-    mutationFn: async (req: HackRequest) =>
-      await client.hack(req, bearer.data ?? undefined).response,
+    mutationFn: async (req: HackRequest) => {
+      const payload = {
+        submission: req.submission,
+        testCaseTxt:
+          req.testCase.oneofKind === "txt" ? req.testCase.txt : undefined,
+        testCaseCpp:
+          req.testCase.oneofKind === "cpp" ? req.testCase.cpp : undefined,
+      };
+      const res = await postHack(payload, idToken.data ?? undefined);
+      return toHackResponseProto(res);
+    },
     ...options,
   });
 };
@@ -409,16 +422,12 @@ export const useHackInfo = (
   id: number,
   options?: Omit<UseQueryOptions<HackInfoResponse>, "queryKey" | "queryFn">,
 ): UseQueryResult<HackInfoResponse> => {
-  const bearer = useBearer();
   return useQuery({
     queryKey: ["hackInfo", String(id)],
-    queryFn: async () =>
-      await client.hackInfo(
-        {
-          id: id,
-        },
-        bearer.data ?? undefined,
-      ).response,
+    queryFn: async () => {
+      const res = await fetchHackInfo(id);
+      return toHackInfoProto(res);
+    },
     ...options,
   });
 };
@@ -430,20 +439,48 @@ export const useHackList = (
   skip: number,
   limit: number,
 ): UseQueryResult<HackListResponse> => {
-  const bearer = useBearer();
   return useQuery({
     queryKey: ["hackList", user, status, order, skip, limit],
-    queryFn: async () =>
-      await client.hackList(
-        {
-          user: user,
-          status: status,
-          order: order,
-          skip: skip,
-          limit: limit,
-        },
-        bearer.data ?? undefined,
-      ).response,
+    queryFn: async () => {
+      const res = await fetchHackList({ user, status, order, skip, limit });
+      return {
+        hacks: res.hacks.map(toHackOverviewProto),
+        count: res.count,
+      } satisfies HackListResponse;
+    },
     structuralSharing: false,
   });
+};
+
+const toHackResponseProto = (
+  res: OpenApi["schemas"]["HackResponse"],
+): HackResponse => ({ id: res.id });
+
+const toHackOverviewProto = (
+  overview: OpenApi["schemas"]["HackOverview"],
+): HackOverview => ({
+  id: overview.id,
+  submissionId: overview.submission_id,
+  status: overview.status,
+  userName: overview.user_name,
+  time: overview.time,
+  memory: overview.memory !== undefined ? BigInt(overview.memory) : undefined,
+  hackTime: TimestampMessage.fromDate(new Date(overview.hack_time)),
+});
+
+const toHackInfoProto = (
+  res: OpenApi["schemas"]["HackInfoResponse"],
+): HackInfoResponse => {
+  let testCase: HackInfoResponse["testCase"] = { oneofKind: undefined };
+  if (res.test_case_txt) {
+    testCase = { oneofKind: "txt", txt: decodeBase64(res.test_case_txt) };
+  } else if (res.test_case_cpp) {
+    testCase = { oneofKind: "cpp", cpp: decodeBase64(res.test_case_cpp) };
+  }
+  return {
+    overview: toHackOverviewProto(res.overview),
+    testCase,
+    stderr: res.stderr ? decodeBase64(res.stderr) : undefined,
+    judgeOutput: res.judge_output ? decodeBase64(res.judge_output) : undefined,
+  } satisfies HackInfoResponse;
 };

--- a/src/api/http_client.ts
+++ b/src/api/http_client.ts
@@ -140,6 +140,10 @@ type SubmissionListQueryParams = NonNullable<
   paths["/submissions"]["get"]["parameters"]["query"]
 >;
 
+type HackListQueryParams = NonNullable<
+  paths["/hacks"]["get"]["parameters"]["query"]
+>;
+
 const dropUndefined = <T extends Record<string, unknown>>(obj: T): T => {
   return Object.fromEntries(
     Object.entries(obj).filter(([, value]) => value !== undefined),
@@ -189,6 +193,92 @@ export async function fetchSubmissionInfo(
     params: { path: { id } },
   });
   return unwrap<components["schemas"]["SubmissionInfoResponse"]>(r);
+}
+
+// Hacks
+export type HackPayload = {
+  submission: number;
+  testCaseTxt?: Uint8Array;
+  testCaseCpp?: Uint8Array;
+};
+
+export type HackListQuery = {
+  user?: string;
+  status?: string;
+  order?: string;
+  skip?: number;
+  limit?: number;
+};
+
+const encodeBase64 = (value: Uint8Array): string => {
+  const globalBtoa = (
+    globalThis as {
+      btoa?: (data: string) => string;
+    }
+  ).btoa;
+  if (typeof globalBtoa === "function") {
+    let binary = "";
+    value.forEach((b) => {
+      binary += String.fromCharCode(b);
+    });
+    return globalBtoa(binary);
+  }
+  const globalBuffer = (
+    globalThis as {
+      Buffer?: {
+        from: (data: Uint8Array) => { toString: (encoding: string) => string };
+      };
+    }
+  ).Buffer;
+  if (globalBuffer) {
+    return globalBuffer.from(value).toString("base64");
+  }
+  throw new Error("Base64 encoder is not available in this environment");
+};
+
+export async function postHack(
+  payload: HackPayload,
+  idToken?: string | null,
+): Promise<components["schemas"]["HackResponse"]> {
+  const body = dropUndefined<components["schemas"]["CreateHackRequest"]>({
+    submission: payload.submission,
+    test_case_txt: payload.testCaseTxt
+      ? encodeBase64(payload.testCaseTxt)
+      : undefined,
+    test_case_cpp: payload.testCaseCpp
+      ? encodeBase64(payload.testCaseCpp)
+      : undefined,
+  });
+  const r = await client.POST("/hacks", {
+    body,
+    headers: authHeaders(idToken),
+  });
+  return unwrap<components["schemas"]["HackResponse"]>(r);
+}
+
+export async function fetchHackInfo(
+  id: number,
+): Promise<components["schemas"]["HackInfoResponse"]> {
+  const r = await client.GET("/hacks/{id}", {
+    params: { path: { id } },
+  });
+  return unwrap<components["schemas"]["HackInfoResponse"]>(r);
+}
+
+export async function fetchHackList(
+  query: HackListQuery,
+): Promise<components["schemas"]["HackListResponse"]> {
+  const params = dropUndefined<HackListQueryParams>({
+    skip: query.skip,
+    limit: query.limit,
+    user: query.user,
+    status: query.status,
+    order: query.order,
+  });
+  const r = await client.GET("/hacks", {
+    params: { query: params },
+  });
+  return unwrap<components["schemas"]["HackListResponse"]>(r);
 }
 
 export type {};


### PR DESCRIPTION
## Summary
- add REST client helpers for hack create/list/info endpoints
- switch hack React Query hooks from gRPC to REST while preserving proto-shaped return values
- encode/decode byte fields for OpenAPI byte payloads

## Tests
- npm run lint
- npm run prettier:check
- npm run build