### PR TITLE
feat(frontend): migrate monitoring and rejudge to REST

### DIFF
--- a/src/api/client_wrapper.ts
+++ b/src/api/client_wrapper.ts
@@ -6,8 +6,6 @@ import {
   UseQueryOptions,
   UseQueryResult,
 } from "@tanstack/react-query";
-import { LibraryCheckerServiceClient } from "../proto/library_checker.client";
-import { GrpcWebFetchTransport } from "@protobuf-ts/grpcweb-transport";
 import {
   ChangeCurrentUserInfoRequest,
   CurrentUserInfoResponse,
@@ -18,6 +16,7 @@ import {
   HackOverview,
   MonitoringResponse,
   RejudgeRequest,
+  RejudgeResponse,
   SubmissionCaseResult,
   SubmissionInfoResponse,
   SubmissionListResponse,
@@ -45,6 +44,8 @@ import {
   fetchHackInfo,
   fetchHackList,
   postHack,
+  fetchMonitoring,
+  postRejudge,
 } from "./http_client";
 import type { components as OpenApi } from "../openapi/types";
 import { Timestamp as TimestampMessage } from "../proto/google/protobuf/timestamp";
@@ -102,12 +103,6 @@ export const useChangeCurrentUserInfoMutation = () => {
   });
 };
 
-const transport = new GrpcWebFetchTransport({
-  baseUrl: import.meta.env.VITE_API_URL,
-});
-const client = new LibraryCheckerServiceClient(transport);
-export default client;
-
 export const useLangList = (): UseQueryResult<
   OpenApi["schemas"]["LangListResponse"]
 > =>
@@ -130,7 +125,10 @@ export const useRanking = (
 export const useMonitoring = (): UseQueryResult<MonitoringResponse> =>
   useQuery({
     queryKey: ["monitoring"],
-    queryFn: async () => await client.monitoring({}, {}).response,
+    queryFn: async () => {
+      const res = await fetchMonitoring();
+      return toMonitoringProto(res);
+    },
     refetchInterval: 30000, // Refetch every 30 seconds for real-time monitoring
   });
 
@@ -277,12 +275,26 @@ export const useSubmitMutation = (
 };
 
 export const useRejudgeMutation = () => {
-  const bearer = useBearer();
-  return useMutation({
-    mutationFn: async (req: RejudgeRequest) =>
-      await client.rejudge(req, bearer.data ?? undefined).response,
+  const idToken = useIdToken();
+  return useMutation<RejudgeResponse, Error, RejudgeRequest>({
+    mutationFn: async (req: RejudgeRequest) => {
+      await postRejudge(req.id, idToken.data ?? undefined);
+      return {};
+    },
   });
 };
+
+const toMonitoringProto = (
+  res: OpenApi["schemas"]["MonitoringResponse"],
+): MonitoringResponse => ({
+  totalUsers: res.total_users,
+  totalSubmissions: res.total_submissions,
+  taskQueue: {
+    pendingTasks: res.task_queue.pending_tasks,
+    runningTasks: res.task_queue.running_tasks,
+    totalTasks: res.task_queue.total_tasks,
+  },
+});
 
 const toSubmissionInfoProto = (
   res: OpenApi["schemas"]["SubmissionInfoResponse"],
@@ -376,23 +388,6 @@ const toSolvedStatusMap = (
     }
   });
   return mapped;
-};
-
-const useBearer = () => {
-  const idToken = useIdToken();
-  return useQuery({
-    queryKey: ["api", "bearer", idToken.data],
-    queryFn: () => {
-      return idToken.data
-        ? {
-            meta: {
-              authorization: "bearer " + idToken.data,
-            },
-          }
-        : null;
-    },
-    enabled: !idToken.isLoading,
-  });
 };
 
 export const useHackMutation = (

--- a/src/api/http_client.ts
+++ b/src/api/http_client.ts
@@ -39,6 +39,13 @@ export async function fetchRanking(skip = 0, limit = 100) {
   return unwrap<components["schemas"]["RankingResponse"]>(r);
 }
 
+export async function fetchMonitoring(): Promise<
+  components["schemas"]["MonitoringResponse"]
+> {
+  const r = await client.GET("/monitoring");
+  return unwrap<components["schemas"]["MonitoringResponse"]>(r);
+}
+
 export async function fetchProblemList(): Promise<
   components["schemas"]["ProblemListResponse"]
 > {
@@ -193,6 +200,17 @@ export async function fetchSubmissionInfo(
     params: { path: { id } },
   });
   return unwrap<components["schemas"]["SubmissionInfoResponse"]>(r);
+}
+
+export async function postRejudge(
+  id: number,
+  idToken?: string | null,
+): Promise<components["schemas"]["RejudgeResponse"]> {
+  const r = await client.POST("/submissions/{id}/rejudge", {
+    params: { path: { id } },
+    headers: authHeaders(idToken),
+  });
+  return unwrap<components["schemas"]["RejudgeResponse"]>(r);
 }
 
 // Hacks

--- a/src/openapi/types.ts
+++ b/src/openapi/types.ts
@@ -8,6 +8,10 @@ export interface paths {
     /** Get ranking */
     get: operations["getRanking"];
   };
+  "/monitoring": {
+    /** Get monitoring data */
+    get: operations["getMonitoring"];
+  };
   "/problems": {
     /** Get problems */
     get: operations["getProblems"];
@@ -35,6 +39,10 @@ export interface paths {
   "/submissions/{id}": {
     /** Get submission info */
     get: operations["getSubmissionInfo"];
+  };
+  "/submissions/{id}/rejudge": {
+    /** Rejudge a submission */
+    post: operations["postRejudge"];
   };
   "/hacks": {
     /** List hacks */
@@ -206,6 +214,7 @@ export interface components {
       /** Format: int32 */
       id: number;
     };
+    RejudgeResponse: Record<string, never>;
     SubmissionOverview: {
       /** Format: int32 */
       id: number;
@@ -246,6 +255,21 @@ export interface components {
       compile_error?: string;
       can_rejudge: boolean;
       case_results?: components["schemas"]["SubmissionCaseResult"][];
+    };
+    TaskQueueInfo: {
+      /** Format: int32 */
+      pending_tasks: number;
+      /** Format: int32 */
+      running_tasks: number;
+      /** Format: int32 */
+      total_tasks: number;
+    };
+    MonitoringResponse: {
+      /** Format: int32 */
+      total_users: number;
+      /** Format: int32 */
+      total_submissions: number;
+      task_queue: components["schemas"]["TaskQueueInfo"];
     };
   };
   responses: never;
@@ -294,6 +318,17 @@ export interface operations {
       200: {
         content: {
           "application/json": components["schemas"]["RankingResponse"];
+        };
+      };
+    };
+  };
+  /** Get monitoring data */
+  getMonitoring: {
+    responses: {
+      /** @description OK */
+      200: {
+        content: {
+          "application/json": components["schemas"]["MonitoringResponse"];
         };
       };
     };
@@ -399,6 +434,22 @@ export interface operations {
       200: {
         content: {
           "application/json": components["schemas"]["SubmissionInfoResponse"];
+        };
+      };
+    };
+  };
+  /** Rejudge a submission */
+  postRejudge: {
+    parameters: {
+      path: {
+        id: components["parameters"]["SubmissionId"];
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        content: {
+          "application/json": components["schemas"]["RejudgeResponse"];
         };
       };
     };


### PR DESCRIPTION
## Summary
- add REST client helpers for monitoring and rejudge endpoints
- switch `useMonitoring` and `useRejudgeMutation` from gRPC to REST
- regenerate OpenAPI types from the judge REST spec
- remove the remaining gRPC client usage from `client_wrapper.ts`

## Dependency
- Depends on yosupo06/library-checker-judge#564 for `GET /monitoring` and `POST /submissions/{id}/rejudge`

## Tests
- npm run lint
- npm run prettier:check
- npm run build