### PR TITLE
fix(frontend): use local fake GCS bucket URL

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,6 +1,6 @@
 VITE_API_URL=http://localhost:12380
 VITE_REST_API_URL=http://localhost:12381
-VITE_PUBLIC_BUCKET_URL=http://127.0.0.1:9000/testcase-public/
+VITE_PUBLIC_BUCKET_URL=http://localhost:4443/testcase-public/
 VITE_FIREBASE_API_KEY=AIzaSyDYcSXsFQLNJanlr9qS0k4e6gRNMAksKUU
 VITE_FIREBASE_AUTH_DOMAIN=dev-library-checker-project.firebaseapp.com
 VITE_FIREBASE_AUTH_EMULATOR_URL=http://localhost:9099


### PR DESCRIPTION
## Summary
- point development public bucket URL at the fake GCS service exposed by local compose
- replace the stale `localhost:9000` value with `localhost:4443`

## Verification
- Confirmed the app works locally with this env change together with yosupo06/library-checker-judge#565